### PR TITLE
libusbgx: fix INSERT_TAILQ_STRING_ORDER

### DIFF
--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -188,6 +188,7 @@ struct usbg_udc
 				if (strcmp((ToInsert)->NameField, _cur->NameField) > 0) \
 					continue; \
 				TAILQ_INSERT_BEFORE(_cur, (ToInsert), NodeField); \
+				break; \
 			} \
 		} \
 	} while (0)


### PR DESCRIPTION
If inserting a node in the middle of a list that's long enough (> 3) the macro
will add the node in the right spot and then step on the rest of entries until
the end.

Signed-off-by: Nicolas Saenz Julienne <nicolassaenzj@gmail.com>