### PR TITLE
libusbgx: fix: Add missing include in usb_common.c

### DIFF
--- a/src/usbg_common.c
+++ b/src/usbg_common.c
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <malloc.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 


### PR DESCRIPTION
snprintf is used multiple times in usb_common.c,
but it did not include stdio.h before.