### PR TITLE
Compilation fixes.

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -7,4 +7,4 @@ gadget_export_SOURCE = gadget-export.c
 gadget_import_SOURCE = gadget-import.c
 show_udcs_SOURCE = show-udcs.c
 AM_CPPFLAGS=-I$(top_srcdir)/include/
-AM_LDFLAGS=-L../src/ -lusbgx
+AM_LDFLAGS=-L$(top_srcdir)/src/ -lusbgx

--- a/src/usbg_common.c
+++ b/src/usbg_common.c
@@ -327,6 +327,7 @@ int usbg_set_ether_addr(const char *path, const char *name,
 	return usbg_write_string(path, name, attr, str_addr);
 }
 
+#ifdef HAS_GADGET_SCHEMES
 int usbg_get_config_node_int(config_setting_t *root,
 					   const char *node_name, void *val)
 {
@@ -458,6 +459,7 @@ int usbg_set_config_node_ether_addr(config_setting_t *root,
 	usbg_ether_ntoa_r(val, str_addr);
 	return usbg_set_config_node_string(root, node_name, &ptr);
 }
+#endif /* HAS_GADGET_SCHEMES */
 
 void usbg_cleanup_function(struct usbg_function *f)
 {

--- a/src/usbg_common.c
+++ b/src/usbg_common.c
@@ -459,6 +459,56 @@ int usbg_set_config_node_ether_addr(config_setting_t *root,
 	usbg_ether_ntoa_r(val, str_addr);
 	return usbg_set_config_node_string(root, node_name, &ptr);
 }
+#else
+/* Dummy implementations.
+ */
+int usbg_get_config_node_int(config_setting_t *root,
+					   const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
+
+int usbg_get_config_node_bool(config_setting_t *root,
+					   const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
+
+int usbg_get_config_node_string(config_setting_t *root,
+					   const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
+
+int usbg_get_config_node_ether_addr(config_setting_t *root,
+					      const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
+
+int usbg_set_config_node_int(config_setting_t *root,
+					   const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
+
+int usbg_set_config_node_bool(config_setting_t *root,
+					   const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
+
+int usbg_set_config_node_string(config_setting_t *root,
+					   const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
+
+int usbg_set_config_node_ether_addr(config_setting_t *root,
+					      const char *node_name, void *val)
+{
+	return USBG_ERROR_NOT_SUPPORTED;
+}
 #endif /* HAS_GADGET_SCHEMES */
 
 void usbg_cleanup_function(struct usbg_function *f)


### PR DESCRIPTION
Trivial fix for out-out-tree linking the examples.
Fix to make --without-libconfig or --disable-gadget-schemes actually work.

(Sorry about the name confusion: xbbn is also me)