### PR TITLE
OS descriptors support v2

### DIFF
--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -1004,6 +1004,14 @@ extern const char *usbg_get_binding_name(usbg_binding *b);
  */
 extern int usbg_get_binding_name_s(usbg_binding *b, char *buf, int len);
 
+/**
+ * @brief Set configuration used for hosts using OS Descriptors
+ * @param g Pointer to gadget
+ * @param c Pointer to config
+ * @return 0 on success, usbg_error on failure.
+ */
+extern int usbg_set_os_desc_config(usbg_gadget *g, usbg_config *c);
+
 /* USB gadget setup and teardown */
 
 /**

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -218,6 +218,15 @@ typedef enum
 	USBG_FUNCTION_TYPE_MAX,
 } usbg_function_type;
 
+/**
+ * @brief USB OS Descriptor function attributes
+ */
+struct usbg_function_os_desc
+{
+	char *compatible_id;
+	char *sub_compatible_id;
+};
+
 /* Error codes */
 
 /**
@@ -791,6 +800,40 @@ extern int usbg_get_function_attrs(usbg_function *f, void *f_attrs);
  * @return 0 on success, usbg_error if error occurred
  */
 extern int usbg_set_function_attrs(usbg_function *f, void *f_attrs);
+
+/**
+ * @brief Get OS Descriptor compatibility of given function
+ * @param f Pointer to function
+ * @param f_os_desc OS Descriptor compatibility to be filled
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_get_interf_os_desc(usbg_function *f,
+		struct usbg_function_os_desc *f_os_desc);
+
+/**
+ * @brief Free OS Descriptor function attributes
+ * @details This function releases the memory allocated for function
+ *          atrributes for struct usbg_function_os_desc.
+ * @param f_os_desc OS Descriptor function attributes to be released
+ */
+static inline void usbg_free_interf_os_desc(
+			struct usbg_function_os_desc *f_os_desc)
+{
+	if (f_os_desc)
+		return;
+
+	free(f_os_desc->compatible_id);
+	free(f_os_desc->sub_compatible_id);
+}
+
+/**
+ * @brief Set OS Descriptor compatibility of given function
+ * @param f Pointer to function
+ * @param f_os_desc OS Descriptor compatibility to be set
+ * @return 0 on success, usbg_error if error occurred
+ */
+extern int usbg_set_interf_os_desc(usbg_function *f,
+		const struct usbg_function_os_desc *f_os_desc);
 
 /* USB configurations allocation and configuration */
 

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -54,6 +54,8 @@ extern "C" {
 #define USBG_MAX_NAME_LENGTH 40
 /* Dev name for ffs is a part of function name, we subtract 4 char for "ffs." */
 #define USBG_MAX_DEV_LENGTH (USBG_MAX_NAME_LENGTH - 4)
+/* ConfigFS just like SysFS uses page size as max size of file content */
+#define USBG_MAX_FILE_SIZE 4096
 
 /**
  * @brief Additional option for usbg_rm_* functions.
@@ -152,6 +154,28 @@ struct usbg_gadget_strs
 	char *product;
 	char *serial;
 };
+
+/**
+ * @brief USB gadget Microsoft OS Descriptors
+ */
+struct usbg_gadget_os_descs
+{
+	bool use;
+	uint8_t b_vendor_code;
+	char *qw_sign;
+};
+
+/**
+ * @typedef usbg_gadget_os_desc_strs
+ * @brief Microsoft OS Descriptors strings
+ */
+typedef enum {
+	USBG_GADGET_OS_DESC_MIN = 0,
+	OS_DESC_USE = USBG_GADGET_OS_DESC_MIN,
+	OS_DESC_B_VENDOR_CODE,
+	OS_DESC_QW_SIGN,
+	USBG_GADGET_OS_DESC_MAX,
+} usbg_gadget_os_desc_strs;
 
 /**
  * @brief USB configuration attributes
@@ -424,6 +448,13 @@ extern int usbg_lookup_gadget_str(const char *name);
 extern const char *usbg_get_gadget_str_name(usbg_gadget_str str);
 
 /**
+ * @brief Get name of selected OS Descriptor string
+ * @param str OS Descriptor string code
+ * @return Name of OS Descriptor associated with this code
+ */
+extern const char *usbg_get_gadget_os_desc_name(usbg_gadget_os_desc_strs str);
+
+/**
  * @brief Set selected attribute to value
  * @param g Pointer to gadget
  * @param attr Code of selected attribute
@@ -636,6 +667,41 @@ extern int usbg_set_gadget_manufacturer(usbg_gadget *g, int lang,
  */
 extern int usbg_set_gadget_product(usbg_gadget *g, int lang,
 				   const char *prd);
+
+/**
+ * @brief Get the USB gadget OS Descriptor
+ * @param g Pointer to gadget
+ * @param g_os_descs Structure to be filled
+ * @return 0 on success usbg_error if error occurred
+ */
+
+extern int usbg_get_gadget_os_descs(usbg_gadget *g,
+		struct usbg_gadget_os_descs *g_os_descs);
+
+/**
+ * @brief Free OS Descriptor attributes
+ * @details This function releases the memory allocated for USB
+ *          gadget OS Descriptor atrributes.
+ * @param g_os_desc OS Descriptor attributes to be released
+ */
+static inline void usbg_free_gadget_os_desc(
+			struct usbg_gadget_os_descs *g_os_desc)
+{
+	if (g_os_desc)
+		return;
+
+	free(g_os_desc->qw_sign);
+}
+
+/**
+ * @brief Set the USB gadget OS Descriptor
+ * @param g Pointer to gadget
+ * @param g_os_descs Structure to be filled
+ * @return 0 on success usbg_error if error occurred
+ */
+
+extern int usbg_set_gadget_os_descs(usbg_gadget *g,
+		const struct usbg_gadget_os_descs *g_os_descs);
 
 /* USB function allocation and configuration */
 

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -203,6 +203,7 @@ struct usbg_udc
 #define CONFIGS_DIR "configs"
 #define FUNCTIONS_DIR "functions"
 #define GADGETS_DIR "usb_gadget"
+#define OS_DESC_DIR "os_desc"
 
 static inline int file_select(const struct dirent *dent)
 {

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -110,6 +110,7 @@ struct usbg_gadget
 	usbg_state *parent;
 	config_t *last_failed_import;
 	usbg_udc *udc;
+	usbg_config *os_desc_binding;
 };
 
 struct usbg_config

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -381,6 +381,12 @@ typedef int (*usbg_import_node_func)(config_setting_t *root,
 typedef int (*usbg_export_node_func)(config_setting_t *root,
 				     const char *node_name, void *val);
 
+int usbg_get_config_node_os_desc(config_setting_t *root, const char *iname,
+				struct usbg_function_os_desc *f_os_desc);
+
+int usbg_set_config_node_os_desc(config_setting_t *root, const char *iname,
+				const struct usbg_function_os_desc *f_os_desc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -52,6 +52,9 @@ struct usbg_function_type
 	/* Name of this function type */
 	char *name;
 
+	/* OS Descriptor interface name */
+	char *os_desc_iname;
+
 	/* Called to allocate instance of function */
 	int (*alloc_inst)(struct usbg_function_type *, usbg_function_type,
 			  const char *, const char *, usbg_gadget *,

--- a/src/function/ether.c
+++ b/src/function/ether.c
@@ -193,6 +193,7 @@ struct usbg_function_type usbg_f_type_eem = {
 
 struct usbg_function_type usbg_f_type_rndis = {
 	.name = "rndis",
+	.os_desc_iname = "rndis",
 	ETHER_FUNCTION_OPTS
 };
 

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -361,6 +361,7 @@ static usbg_gadget *usbg_allocate_gadget(const char *path, const char *name,
 	g->path = strdup(path);
 	g->parent = parent;
 	g->udc = NULL;
+	g->os_desc_binding = NULL;
 
 	if (!(g->name) || !(g->path))
 		goto cleanup;
@@ -645,6 +646,83 @@ out:
 	return ret;
 }
 
+static int usbg_parse_gadget_os_desc_binding(usbg_gadget *g)
+{
+	int i, n, nmb, id;
+	int ret = USBG_SUCCESS;
+	struct dirent **dent;
+	char bpath[USBG_MAX_PATH_LENGTH];
+	char target[USBG_MAX_PATH_LENGTH];
+	char *target_name;
+	usbg_config *c;
+	char *label = NULL;
+	int end;
+
+	end = snprintf(bpath, sizeof(bpath), "%s/%s/%s", g->path, g->name,
+			OS_DESC_DIR);
+	if (end >= sizeof(bpath)) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	n = scandir(bpath, &dent, bindings_select, alphasort);
+	if (n < 0) {
+		ret = usbg_translate_error(errno);
+		goto out;
+	}
+
+	/* Not having any binding is ok */
+	if (n < 1) {
+		ret = USBG_SUCCESS;
+		goto out;
+	}
+
+
+	/*
+	 * Only one configuration can be bound to os_descx, n should
+	 * equal 1.
+	 */
+	nmb = snprintf(&(bpath[end]), sizeof(bpath) - end,
+			"/%s", dent[0]->d_name);
+
+	for (i = 0; i < n; i++)
+		free(dent[i]);
+	free(dent);
+
+	if (nmb >= sizeof(bpath) - end) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	nmb = readlink(bpath, target, sizeof(target) - 1 );
+	if (nmb < 0) {
+		ret = usbg_translate_error(errno);
+		goto out;
+	}
+
+	/* readlink() don't add this, so we have to do it manually */
+	target[nmb] = '\0';
+	/* Target contains a full path but we only need function dir name */
+	target_name = strrchr(target, '/') + 1;
+	id = usbg_split_config_label_id(target_name, &label);
+	if (id <= 0) {
+		ret = id;
+		goto out;
+	}
+
+	c = usbg_get_config(g, id, label);
+	if (!c) {
+		ret = USBG_ERROR_NO_MEM;
+		goto out;
+	}
+
+	g->os_desc_binding = c;
+
+out:
+	return ret;
+}
+
+
 static int usbg_parse_config(const char *path, const char *name,
 		usbg_gadget *g)
 {
@@ -871,6 +949,10 @@ static inline int usbg_parse_gadget(usbg_gadget *g)
 		goto out;
 
 	ret = usbg_parse_configs(g->path, g);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	ret = usbg_parse_gadget_os_desc_binding(g);
 out:
 	return ret;
 }
@@ -1148,6 +1230,11 @@ int usbg_rm_binding(usbg_binding *b)
 
 out:
 	return ret;
+}
+
+usbg_config *usbg_get_os_desc_binding(usbg_gadget *g)
+{
+	return g->os_desc_binding;
 }
 
 int usbg_rm_config(usbg_config *c, int opts)
@@ -2352,6 +2439,50 @@ int usbg_get_binding_name_s(usbg_binding *b, char *buf, int len)
 		return USBG_ERROR_INVALID_PARAM;
 
 	return snprintf(buf, len, "%s", b->name);
+}
+
+int usbg_set_os_desc_config(usbg_gadget *g, usbg_config *c)
+{
+	char bpath[USBG_MAX_PATH_LENGTH];
+	char fpath[USBG_MAX_PATH_LENGTH];
+	int free_space, nmb;
+	int ret;
+
+	if (!g || !c) {
+		ret = USBG_ERROR_INVALID_PARAM;
+		goto out;
+	}
+
+	if (g->os_desc_binding) {
+		ERROR("os desc binding exist\n");
+		ret = USBG_ERROR_EXIST;
+		goto out;
+	}
+
+	nmb = snprintf(fpath, sizeof(fpath), "%s/%s", c->path, c->name);
+	if (nmb >= sizeof(fpath)) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	nmb = snprintf(bpath, sizeof(bpath), "%s/%s/%s/%s", g->path, g->name,
+			OS_DESC_DIR, c->name);
+	if (nmb >= sizeof(bpath)) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	ret = symlink(fpath, bpath);
+	if (ret != 0) {
+		ret = usbg_translate_error(errno);
+		goto out;
+	}
+
+	g->os_desc_binding = c;
+
+	return USBG_SUCCESS;
+out:
+	return ret;
 }
 
 int usbg_enable_gadget(usbg_gadget *g, usbg_udc *udc)

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2010,6 +2010,70 @@ out:
 	return ret;
 }
 
+int usbg_get_interf_os_desc(usbg_function *f,
+			struct usbg_function_os_desc *f_os_desc)
+{
+	int ret = USBG_ERROR_NOT_SUPPORTED;
+	int nmb;
+	char spath[USBG_MAX_PATH_LENGTH];
+	const char *iname = f->ops->os_desc_iname;
+
+	if (!iname)
+		return ret;
+
+	nmb = snprintf(spath, sizeof(spath), "%s/%s/%s/interface.%s", f->path,
+			f->name, OS_DESC_DIR, iname);
+	if (nmb >= sizeof(spath)) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	ret = usbg_read_string_alloc(spath, "", "compatible_id",
+				&f_os_desc->compatible_id);
+	if (ret)
+		return ret;
+
+	ret = usbg_read_string_alloc(spath, "", "sub_compatible_id",
+				&f_os_desc->sub_compatible_id);
+	if (ret)
+		return ret;
+
+out:
+	return ret;
+}
+
+int usbg_set_interf_os_desc(usbg_function *f,
+			const struct usbg_function_os_desc *f_os_desc)
+{
+	int ret = USBG_ERROR_NOT_SUPPORTED;
+	int nmb;
+	char spath[USBG_MAX_PATH_LENGTH];
+	const char *iname = f->ops->os_desc_iname;
+
+	if (!iname)
+		return ret;
+
+	nmb = snprintf(spath, sizeof(spath), "%s/%s/%s/interface.%s", f->path,
+			f->name, OS_DESC_DIR, iname);
+	if (nmb >= sizeof(spath)) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	ret = usbg_write_string(spath, "", "compatible_id",
+			f_os_desc->compatible_id);
+	if (ret)
+		return ret;
+
+	ret = usbg_write_string(spath, "", "sub_compatible_id",
+			f_os_desc->sub_compatible_id);
+	if (ret)
+		return ret;
+
+out:
+	return ret;
+}
+
 int usbg_create_config(usbg_gadget *g, int id, const char *label,
 		       const struct usbg_config_attrs *c_attrs,
 		       const struct usbg_config_strs *c_strs,

--- a/src/usbg_common.c
+++ b/src/usbg_common.c
@@ -359,6 +359,64 @@ int usbg_get_dev(const char *path, const char *name, const char *attr,
 	return 0;
 }
 
+int usbg_get_config_node_os_desc(config_setting_t *root, const char *iname,
+				struct usbg_function_os_desc *f_os_desc)
+{
+	const char *str_addr;
+	int ret;
+
+	ret = usbg_get_config_node_string(root, "compatible_id", &str_addr);
+	/* if error */
+	if (ret < 0)
+		return ret;
+
+	if (ret)
+		f_os_desc->compatible_id = strdup(str_addr);
+
+	ret = usbg_get_config_node_string(root, "sub_compatible_id", &str_addr);
+	/* if error */
+	if (ret < 0)
+		return ret;
+
+	if (ret)
+		f_os_desc->sub_compatible_id = strdup(str_addr);
+
+	return USBG_SUCCESS;
+}
+
+int usbg_set_config_node_os_desc(config_setting_t *root, const char *iname,
+				const struct usbg_function_os_desc *f_os_desc)
+{
+	int ret;
+	config_setting_t *node;
+
+	if (f_os_desc->compatible_id) {
+		node = config_setting_add(root, "compatible_id",
+				CONFIG_TYPE_STRING);
+		if (!node)
+			return USBG_ERROR_NO_MEM;
+
+		ret = config_setting_set_string(node,
+				f_os_desc->compatible_id);
+		if (ret != CONFIG_TRUE)
+			return USBG_ERROR_OTHER_ERROR;
+	}
+
+	if (f_os_desc->sub_compatible_id) {
+		node = config_setting_add(root, "sub_compatible_id",
+				CONFIG_TYPE_STRING);
+		if (!node)
+			return USBG_ERROR_NO_MEM;
+
+		ret = config_setting_set_string(node,
+				f_os_desc->sub_compatible_id);
+		if (ret != CONFIG_TRUE)
+			return USBG_ERROR_OTHER_ERROR;
+	}
+
+	return USBG_SUCCESS;
+}
+
 void usbg_cleanup_function(struct usbg_function *f)
 {
 	free(f->path);

--- a/src/usbg_schemes_libconfig.c
+++ b/src/usbg_schemes_libconfig.c
@@ -1594,19 +1594,6 @@ static int usbg_import_gadget_run(usbg_state *s, config_setting_t *root,
 			goto error;
 	}
 
-	/* OS Descriptors are optional too */
-	node = config_setting_get_member(root, USBG_OS_DESCS_TAG);
-	if (node) {
-		if (!config_setting_is_group(node)) {
-			ret = USBG_ERROR_INVALID_TYPE;
-			goto error2;
-		}
-
-		usbg_ret = usbg_import_gadget_os_descs(node, newg);
-		if (usbg_ret != USBG_SUCCESS)
-			goto error;
-	}
-
 	/* Functions too, because some gadgets may not be fully
 	* configured and don't have any function or have all functions
 	* defined inline in configurations */
@@ -1630,6 +1617,19 @@ static int usbg_import_gadget_run(usbg_state *s, config_setting_t *root,
 			goto error2;
 		}
 		usbg_ret = usbg_import_gadget_configs(node, newg);
+		if (usbg_ret != USBG_SUCCESS)
+			goto error;
+	}
+
+	/* OS Descriptors are optional too, read after configs */
+	node = config_setting_get_member(root, USBG_OS_DESCS_TAG);
+	if (node) {
+		if (!config_setting_is_group(node)) {
+			ret = USBG_ERROR_INVALID_TYPE;
+			goto error2;
+		}
+
+		usbg_ret = usbg_import_gadget_os_descs(node, newg);
 		if (usbg_ret != USBG_SUCCESS)
 			goto error;
 	}

--- a/src/usbg_schemes_libconfig.c
+++ b/src/usbg_schemes_libconfig.c
@@ -20,6 +20,7 @@
 #define USBG_NAME_TAG "name"
 #define USBG_ATTRS_TAG "attrs"
 #define USBG_STRINGS_TAG "strings"
+#define USBG_OS_DESCS_TAG "os_descs"
 #define USBG_FUNCTIONS_TAG "functions"
 #define USBG_CONFIGS_TAG "configs"
 #define USBG_LANG_TAG "lang"
@@ -510,6 +511,61 @@ out:
 	return ret;
 }
 
+static int usbg_export_gadget_os_descs(usbg_gadget *g, config_setting_t *root)
+{
+	config_setting_t *node;
+	struct usbg_gadget_os_descs g_os_descs = {0};
+	int usbg_ret, cfg_ret;
+	int ret = USBG_ERROR_NO_MEM;
+
+	usbg_ret = usbg_get_gadget_os_descs(g, &g_os_descs);
+	if (usbg_ret) {
+		ret = usbg_ret;
+		goto out;
+	}
+
+	node = config_setting_add(root, "use", CONFIG_TYPE_INT);
+	if (!node)
+		goto out;
+
+	cfg_ret = config_setting_set_int(node, g_os_descs.use);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	node = config_setting_add(root, "qw_sign", CONFIG_TYPE_STRING);
+	if (!node)
+		goto out;
+
+	cfg_ret = config_setting_set_string(node, g_os_descs.qw_sign);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	node = config_setting_add(root, "b_vendor_code", CONFIG_TYPE_INT);
+	if (!node)
+		goto out;
+
+	cfg_ret = config_setting_set_format(node, CONFIG_FORMAT_HEX);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	cfg_ret = config_setting_set_int(node, g_os_descs.b_vendor_code);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	ret = 0;
+out:
+	usbg_free_gadget_os_desc(&g_os_descs);
+	return ret;
+}
+
 static int usbg_export_gadget_prep(usbg_gadget *g, config_setting_t *root)
 {
 	config_setting_t *node;
@@ -525,6 +581,15 @@ static int usbg_export_gadget_prep(usbg_gadget *g, config_setting_t *root)
 
 	usbg_ret = usbg_export_gadget_attrs(g, node);
 	if (usbg_ret) {
+		ret = usbg_ret;
+		goto out;
+	}
+
+	node = config_setting_add(root, USBG_OS_DESCS_TAG, CONFIG_TYPE_GROUP);
+	if (!node)
+		goto out;
+	usbg_ret = usbg_export_gadget_os_descs(g, node);
+	if (usbg_ret && usbg_ret != USBG_ERROR_NOT_FOUND) {
 		ret = usbg_ret;
 		goto out;
 	}
@@ -1292,6 +1357,50 @@ out:
 
 }
 
+static int usbg_import_gadget_os_descs(config_setting_t *root, usbg_gadget *g)
+{
+	config_setting_t *node;
+	int usbg_ret;
+	int val;
+	int ret = USBG_ERROR_INVALID_TYPE;
+	const char *str;
+	struct usbg_gadget_os_descs g_os_descs = {0};
+
+#define GET_OPTIONAL_GADGET_ATTR(NAME, FIELD, TYPE)			\
+	do {								\
+		node = config_setting_get_member(root, #NAME);		\
+		if (node) {						\
+			if (!usbg_config_is_int(node))			\
+				goto out;				\
+			val = config_setting_get_int(node);		\
+			if (val < 0 || val > ((1L << (sizeof(TYPE)*8)) - 1)) { \
+				ret = USBG_ERROR_INVALID_VALUE;		\
+				goto out;				\
+			}						\
+			g_os_descs.FIELD = (TYPE)val;			\
+		}							\
+	} while (0)
+
+	GET_OPTIONAL_GADGET_ATTR(use, use, bool);
+	GET_OPTIONAL_GADGET_ATTR(b_vendor_code, b_vendor_code, uint8_t);
+
+#undef GET_OPTIONAL_GADGET_ATTR
+
+	node = config_setting_get_member(root, "qw_sign");
+	if (node) {
+		if (!usbg_config_is_string(node))
+			goto out;
+		str = config_setting_get_string(node);
+		g_os_descs.qw_sign = strdup(str);
+	}
+
+	ret = usbg_set_gadget_os_descs(g, &g_os_descs);
+
+out:
+	usbg_free_gadget_os_desc(&g_os_descs);
+	return ret;
+}
+
 static int usbg_import_gadget_run(usbg_state *s, config_setting_t *root,
 				  const char *name, usbg_gadget **g)
 {
@@ -1330,6 +1439,19 @@ static int usbg_import_gadget_run(usbg_state *s, config_setting_t *root,
 		}
 
 		usbg_ret = usbg_import_gadget_strings(node, newg);
+		if (usbg_ret != USBG_SUCCESS)
+			goto error;
+	}
+
+	/* OS Descriptors are optional too */
+	node = config_setting_get_member(root, USBG_OS_DESCS_TAG);
+	if (node) {
+		if (!config_setting_is_group(node)) {
+			ret = USBG_ERROR_INVALID_TYPE;
+			goto error2;
+		}
+
+		usbg_ret = usbg_import_gadget_os_descs(node, newg);
 		if (usbg_ret != USBG_SUCCESS)
 			goto error;
 	}


### PR DESCRIPTION
Hi Krzysztof,

Finally came around to rebase/retest my work on OS descriptors support. This needs a kernel 4.13 or newer to properly support gadget-export due to two issue:
https://patchwork.kernel.org/patch/9548869/

Both have been accepted and especially the first fix makes life of libusbgx much easier, since UTF-16 to UTF-16 conversion would have added iconv as a dependencies...

Not sure how to do a proper v2 in Github terms, ended up just creating a new pull request.

Best regards,
Stefan