### PR TITLE
libusbgx: fix: Check fclose() return code

### DIFF
--- a/src/usbg_common.c
+++ b/src/usbg_common.c
@@ -164,15 +164,19 @@ int usbg_write_buf(const char *path, const char *name,
 		goto out;
 	}
 
-	ret = fwrite(buf, sizeof(char), len, fp);
-	if (ret < len) {
+	nmb = fwrite(buf, sizeof(char), len, fp);
+	if (nmb < len) {
 		if (ferror(fp))
-			ret = usbg_translate_error(errno);
+			nmb = usbg_translate_error(errno);
 		else
-			ret = USBG_ERROR_IO;
+			nmb = USBG_ERROR_IO;
 	}
 
-	fclose(fp);
+	ret = fclose(fp);
+	if (ret < 0)
+		ret = usbg_translate_error(errno);
+	else
+		ret = nmb;
 out:
 	return ret;
 }
@@ -192,7 +196,7 @@ int usbg_write_int(const char *path, const char *name, const char *file,
 	if (ret > 0)
 		ret = 0;
 
-	return 0;
+	return ret;
 }
 
 int usbg_write_string(const char *path, const char *name,
@@ -204,7 +208,7 @@ int usbg_write_string(const char *path, const char *name,
 	if (ret > 0)
 		ret = 0;
 
-	return 0;
+	return ret;
 }
 
 int ubsg_rm_file(const char *path, const char *name)


### PR DESCRIPTION
According to man fclose:

"The fclose() function may also fail and set errno for any of the
 errors specified for the routines close(2), write(2) or fflush(3)."

So if libc decides to cache our write till closing fd we may
miss the error if we ignore value returned from fclose().

This fixes issue #12 (github).

Reported-by: Noralf Trønnes <noralf@tronnes.org>
Suggested-by: Noralf Trønnes <noralf@tronnes.org>
Signed-off-by: Krzysztof Opasiak <k.opasiak@samsung.com>