### PR TITLE
Disallow creating function with empty instance name

### DIFF
--- a/src/usbg.c
+++ b/src/usbg.c
@@ -2048,7 +2048,7 @@ int usbg_create_function(usbg_gadget *g, usbg_function_type type,
 	int ret = USBG_ERROR_INVALID_PARAM;
 	int n, free_space;
 
-	if (!g || !f || !instance)
+	if (!g || !f || !instance || *instance == '\0')
 		return ret;
 
 	func = usbg_get_function(g, type, instance);


### PR DESCRIPTION
USB function should have both type and instance name.
Mistakenly it was possible to create function with empty instance
name. This may lead to situations like FunctionFS device name
identified by "" or some misleading debug messages from TCM like:

tcm: Activating

Additionaly trying to execute usbg_init() after creating such
a function fails with -3 USBG_ERROR_INVALID_PARAM because it checks
if instance name is not empty.

To avoid this let's add a check in usbg_create_function() that
instance name should have at least one character.

This fixes #19 

If anyone here has any objections to this please let me now as soon as possible.