### PR TITLE
[RFC] Add USBG_VERSION preprocessor symbol

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ endif
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = doxygen.cfg
 library_includedir=$(includedir)/usbg
-library_include_HEADERS = include/usbg/usbg.h
+library_include_HEADERS = include/usbg/usbg.h include/usbg/usbg_version.h
 function_includedir=$(includedir)/usbg/function
 function_include_HEADERS = include/usbg/function/ffs.h include/usbg/function/loopback.h include/usbg/function/midi.h include/usbg/function/ms.h include/usbg/function/net.h include/usbg/function/phonet.h include/usbg/function/serial.h include/usbg/function/hid.h include/usbg/function/uac2.h
 pkgconfigdir = $(libdir)/pkgconfig

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,9 @@ AM_PROG_CC_C_O
 AC_CONFIG_MACRO_DIR([m4])
 AC_DEFINE([_GNU_SOURCE], [], [Use GNU extensions])
 
+USBG_VERSION_HEX=`printf '0x%02x%02x%04x' $(printf '%s' "$PACKAGE_VERSION" | sed -e 's/\./ /g')`
+AC_SUBST([USBG_VERSION_HEX])
+
 AC_ARG_WITH([libconfig],
 	    AS_HELP_STRING([--without-libconfig], [build without using libconfig]),
 	                   [with_libconfig=$withval], [with_libconfig=yes])
@@ -52,6 +55,6 @@ AS_IF([test "x$enable_gadget_schemes" = xyes],
 AM_CONDITIONAL(TEST_GADGET_SCHEMES, [test "x$enable_gadget_schemes" != xno])
 
 LT_INIT
-AC_CONFIG_FILES([Makefile src/Makefile examples/Makefile libusbgx.pc doxygen.cfg])
+AC_CONFIG_FILES([Makefile src/Makefile examples/Makefile include/usbg/usbg_version.h libusbgx.pc doxygen.cfg])
 DX_INIT_DOXYGEN([$PACKAGE_NAME],[doxygen.cfg])
 AC_OUTPUT

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -30,6 +30,8 @@
 #include <stdio.h> /* For FILE * */
 #include <malloc.h>
 
+#include "usbg_version.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/usbg/usbg_version.h.in
+++ b/include/usbg/usbg_version.h.in
@@ -1,0 +1,27 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#ifndef USBG_VERSION_H
+#define USBG_VERSION_H
+
+/**
+ * Make API version integer from major, minor and micro numbers
+ */
+#define USBG_MAKE_VERSION(major, minor, micro) \
+	((major << 24) | (minor << 16) | micro)
+
+/**
+ * Version of libusbgx's that is available.
+ */
+#define USBG_VERSION	@USBG_VERSION_HEX@
+
+#endif

--- a/packaging/libusbgx.spec
+++ b/packaging/libusbgx.spec
@@ -56,6 +56,7 @@ make
 %manifest %{name}.manifest
 %defattr(-,root,root)
 %{_includedir}/usbg/usbg.h
+%{_includedir}/usbg/usbg_version.h
 %{_includedir}/usbg/function/ffs.h
 %{_includedir}/usbg/function/loopback.h
 %{_includedir}/usbg/function/midi.h


### PR DESCRIPTION
This is an RFC because I'm not sure it's the best way to extract a version number for use in a header (I looked at how some other projects do this and some use the header as the definitive source of truth for the version and do not include a package version in `configure.ac` but that would require more intrusive changes).