### PR TITLE
libusbgx: fix --without-libconfig build against glibc-2.28

### DIFF
--- a/src/usbg_common.c
+++ b/src/usbg_common.c
@@ -15,6 +15,7 @@
 
 #include <errno.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <malloc.h>
 #include <stdio.h>


### PR DESCRIPTION
Commit 45c14ef4d5 ("libusbgx: fix build with glibc-2.28 since
<sys/sysmacros.h> is no more included by <sys/types.h>")
fixed this issue for the (default) `--with-libconfig` configuration,
but building `--without-libconfig` still throws a linker error
because `makedev` was assumed to be an external symbol in
`usbg_common.c`.

Include `<sys/sysmacros.h>` there to address this.

Signed-off-by: Ahmad Fatoum \<a.fatoum@pengutronix.de\>

----

I've reviewed instances of `/\b(minor|major|makedev)\b/` and it looks like the instance in `usbg_common.c` is the last remaining that doesn't have the sysmacros in scope.