### PR TITLE
Fix typo in comment

### DIFF
--- a/include/usbg/function/net.h
+++ b/include/usbg/function/net.h
@@ -158,7 +158,7 @@ static inline int usbg_f_net_get_host_addr(usbg_f_net *nf,
 }
 
 /**
- * @brief Set the value of device side MAC address
+ * @brief Set the value of host side MAC address
  * @param[in] nf Pointer to net function
  * @param[in] val Value of attribute which should be set
  * @return 0 on success usbg_error if error occurred.


### PR DESCRIPTION
Hi, 

I start trying to understand the whole structure, still need more time to be able to add some other new support, a bit complex for me

Found a typo currently, I guess it should be `host`, cuz the comment is above `usbg_f_net_set_host_addr`