### PR TITLE
uvc: fix return check on scandir

### DIFF
--- a/src/function/uvc.c
+++ b/src/function/uvc.c
@@ -174,8 +174,8 @@ int init_frames(struct usbg_f_uvc *uvc, int j)
 		return ret;
 	}
 
-	nmb = scandir(fpath, &dent, frame_select, frame_sort);
-	if (nmb < 0) {
+	ret = scandir(fpath, &dent, frame_select, frame_sort);
+	if (ret < 0) {
 		ret = usbg_translate_error(errno);
 		return ret;
 	}


### PR DESCRIPTION
The function init_frames is falsely checking for the negative
result from scandir on an unsigned variable. This will never
be true.

Signed-off-by: Michael Grzeschik <m.grzeschik@pengutronix.de>