### PR TITLE
libusbgx: fix usbg_get_config_node_bool() return value

### DIFF
--- a/src/usbg_common_libconfig.c
+++ b/src/usbg_common_libconfig.c
@@ -53,7 +53,7 @@ int usbg_get_config_node_bool(config_setting_t *root,
 		return USBG_ERROR_INVALID_TYPE;
 	}
 
-	return 0;
+	return 1;
 }
 
 int usbg_get_config_node_string(config_setting_t *root,


### PR DESCRIPTION
A return value of zero means that the setting does not exist, if a value is found the get function should return 1.