### PR TITLE
add support for Webusb descriptor

### DIFF
--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -183,6 +183,31 @@ typedef enum {
 	USBG_GADGET_OS_DESC_MAX,
 } usbg_gadget_os_desc_strs;
 
+
+/**
+ * @brief USB gadget WebUSB Descriptors
+ */
+struct usbg_gadget_webusbs
+{
+	bool use;
+	uint8_t b_vendor_code;
+	uint16_t bcd_version;
+	char *landing_page;
+};
+
+/**
+ * @typedef usbg_gadget_webusb_strs
+ * @brief WebUSB Descriptor strings
+ */
+typedef enum {
+	USBG_GADGET_WEBUSB_MIN = 0,
+	WEBUSB_USE = USBG_GADGET_WEBUSB_MIN,
+	WEBUSB_BVENDORCODE,
+	WEBUSB_BCDVERSION,
+	WEBUSB_LANDINGPAGE,
+	USBG_GADGET_WEBUSB_MAX,
+} usbg_gadget_webusb_strs;
+
 /**
  * @brief USB configuration attributes
  */
@@ -474,6 +499,13 @@ extern const char *usbg_get_gadget_str_name(usbg_gadget_str str);
 extern const char *usbg_get_gadget_os_desc_name(usbg_gadget_os_desc_strs str);
 
 /**
+ * @brief Get name of selected WebUSB string
+ * @param str WebUSB string code
+ * @return Name of WebUSB attribute associated with this code
+ */
+extern const char *usbg_get_gadget_webusb_name(usbg_gadget_webusb_strs str);
+
+/**
  * @brief Set selected attribute to value
  * @param g Pointer to gadget
  * @param attr Code of selected attribute
@@ -721,6 +753,39 @@ static inline void usbg_free_gadget_os_desc(
 
 extern int usbg_set_gadget_os_descs(usbg_gadget *g,
 		const struct usbg_gadget_os_descs *g_os_descs);
+
+/**
+ * @brief Get the USB gadget WebUSB Descriptor
+ * @param g Pointer to gadget
+ * @param g_webusbs Structure to be filled
+ * @return 0 on success usbg_error if error occurred
+ */
+extern int usbg_get_gadget_webusbs(usbg_gadget *g,
+		struct usbg_gadget_webusbs *g_webusbs);
+
+/**
+ * @brief Free WebUSB Descriptor attributes
+ * @details This function releases the memory allocated for USB
+ *          gadget WebUSB Descriptor attributes.
+ * @param g_webusbs WebUSB Descriptor attributes to be released
+ */
+static inline void usbg_free_gadget_webusb(
+			struct usbg_gadget_webusbs *g_webusbs)
+{
+	if (!g_webusbs)
+		return;
+
+	free(g_webusbs->landing_page);
+}
+
+/**
+ * @brief Set the USB gadget WebUSB Descriptor
+ * @param g Pointer to gadget
+ * @param g_webusbs Structure with values to set
+ * @return 0 on success usbg_error if error occurred
+ */
+extern int usbg_set_gadget_webusbs(usbg_gadget *g,
+		const struct usbg_gadget_webusbs *g_webusbs);
 
 /* USB function allocation and configuration */
 

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -208,6 +208,7 @@ struct usbg_udc
 #define FUNCTIONS_DIR "functions"
 #define GADGETS_DIR "usb_gadget"
 #define OS_DESC_DIR "os_desc"
+#define WEBUSB_DIR "webusb"
 
 static inline int file_select(const struct dirent *dent)
 {

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -115,6 +115,16 @@ const char *gadget_os_desc_names[] =
 
 ARRAY_SIZE_SENTINEL(gadget_os_desc_names, USBG_GADGET_OS_DESC_MAX)
 
+const char *gadget_webusb_names[] =
+{
+	"use",
+	"bVendorCode",
+	"bcdVersion",
+	"landingPage",
+};
+
+ARRAY_SIZE_SENTINEL(gadget_webusb_names, USBG_GADGET_WEBUSB_MAX)
+
 int usbg_lookup_function_type(const char *name)
 {
 	int i = USBG_FUNCTION_TYPE_MIN;
@@ -189,6 +199,13 @@ const char *usbg_get_gadget_os_desc_name(usbg_gadget_os_desc_strs str)
 	return str >= USBG_GADGET_OS_DESC_MIN &&
 		str < USBG_GADGET_OS_DESC_MAX ?
 		gadget_os_desc_names[str] : NULL;
+}
+
+const char *usbg_get_gadget_webusb_name(usbg_gadget_webusb_strs str)
+{
+	return str >= USBG_GADGET_WEBUSB_MIN &&
+		str < USBG_GADGET_WEBUSB_MAX ?
+		gadget_webusb_names[str] : NULL;
 }
 
 static int usbg_split_function_instance_type(const char *full_name,
@@ -933,6 +950,47 @@ static int usbg_parse_gadget_os_descs(const char *path, const char *name,
 		goto out;
 
 	g_os_descs->use = val ? true : false;
+out:
+	return ret;
+}
+
+static int usbg_parse_gadget_webusbs(const char *path, const char *name,
+		struct usbg_gadget_webusbs *g_webusbs)
+{
+	int ret;
+	int nmb;
+	char spath[USBG_MAX_PATH_LENGTH];
+	int val;
+
+	nmb = snprintf(spath, sizeof(spath), "%s/%s/%s", path, name,
+			WEBUSB_DIR);
+	if (nmb >= sizeof(spath)) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	ret = usbg_read_string_alloc(spath, "", "landingPage",
+				     &g_webusbs->landing_page);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	ret = usbg_read_hex(spath, "", "bVendorCode", &val);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	g_webusbs->b_vendor_code = (unsigned char)val;
+
+	ret = usbg_read_hex(spath, "", "bcdVersion", &val);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	g_webusbs->bcd_version = (uint16_t)val;
+
+	ret = usbg_read_int(spath, "", "use", 10, &val);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	g_webusbs->use = val ? true : false;
 out:
 	return ret;
 }
@@ -2041,6 +2099,51 @@ int usbg_set_gadget_os_descs(usbg_gadget *g,
 		goto out;
 
 	ret = usbg_write_dec(spath, "", "use", g_os_descs->use);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+out:
+	return ret;
+}
+
+int usbg_get_gadget_webusbs(usbg_gadget *g, struct usbg_gadget_webusbs *g_webusbs)
+{
+	return g && g_webusbs ?
+			usbg_parse_gadget_webusbs(g->path, g->name, g_webusbs)
+			: USBG_ERROR_INVALID_PARAM;
+}
+
+int usbg_set_gadget_webusbs(usbg_gadget *g,
+			    const struct usbg_gadget_webusbs *g_webusbs)
+{
+	int ret;
+	int nmb;
+	char spath[USBG_MAX_PATH_LENGTH];
+
+	nmb = snprintf(spath, sizeof(spath), "%s/%s/%s", g->path, g->name,
+			WEBUSB_DIR);
+	if (nmb >= sizeof(spath)) {
+		ret = USBG_ERROR_PATH_TOO_LONG;
+		goto out;
+	}
+
+	ret = usbg_check_dir(spath);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	ret = usbg_write_string(spath, "", "landingPage", g_webusbs->landing_page);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	ret = usbg_write_hex8(spath, "", "bVendorCode", g_webusbs->b_vendor_code);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	ret = usbg_write_hex16(spath, "", "bcdVersion", g_webusbs->bcd_version);
+	if (ret != USBG_SUCCESS)
+		goto out;
+
+	ret = usbg_write_dec(spath, "", "use", g_webusbs->use);
 	if (ret != USBG_SUCCESS)
 		goto out;
 

--- a/src/usbg_schemes_libconfig.c
+++ b/src/usbg_schemes_libconfig.c
@@ -21,6 +21,7 @@
 #define USBG_ATTRS_TAG "attrs"
 #define USBG_STRINGS_TAG "strings"
 #define USBG_OS_DESCS_TAG "os_descs"
+#define USBG_WEBUSB_TAG "webusb"
 #define USBG_FUNCTIONS_TAG "functions"
 #define USBG_CONFIGS_TAG "configs"
 #define USBG_LANG_TAG "lang"
@@ -655,6 +656,77 @@ out:
 	return ret;
 }
 
+static int usbg_export_gadget_webusbs(usbg_gadget *g, config_setting_t *root)
+{
+	config_setting_t *node;
+	struct usbg_gadget_webusbs g_webusbs = {0};
+	int usbg_ret, cfg_ret;
+	int ret = USBG_ERROR_NO_MEM;
+
+	usbg_ret = usbg_get_gadget_webusbs(g, &g_webusbs);
+	if (usbg_ret) {
+		ret = usbg_ret;
+		goto out;
+	}
+
+	node = config_setting_add(root, "use", CONFIG_TYPE_INT);
+	if (!node)
+		goto out;
+
+	cfg_ret = config_setting_set_int(node, g_webusbs.use);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	node = config_setting_add(root, "bVendorCode", CONFIG_TYPE_INT);
+	if (!node)
+		goto out;
+
+	cfg_ret = config_setting_set_format(node, CONFIG_FORMAT_HEX);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	cfg_ret = config_setting_set_int(node, g_webusbs.b_vendor_code);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	node = config_setting_add(root, "bcdVersion", CONFIG_TYPE_INT);
+	if (!node)
+		goto out;
+
+	cfg_ret = config_setting_set_format(node, CONFIG_FORMAT_HEX);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	cfg_ret = config_setting_set_int(node, g_webusbs.bcd_version);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	node = config_setting_add(root, "landingPage", CONFIG_TYPE_STRING);
+	if (!node)
+		goto out;
+
+	cfg_ret = config_setting_set_string(node, g_webusbs.landing_page);
+	if (cfg_ret != CONFIG_TRUE) {
+		ret = USBG_ERROR_OTHER_ERROR;
+		goto out;
+	}
+
+	ret = 0;
+out:
+	usbg_free_gadget_webusb(&g_webusbs);
+	return ret;
+}
+
 static int usbg_export_gadget_prep(usbg_gadget *g, config_setting_t *root)
 {
 	config_setting_t *node;
@@ -679,6 +751,16 @@ static int usbg_export_gadget_prep(usbg_gadget *g, config_setting_t *root)
 		goto out;
 
 	usbg_ret = usbg_export_gadget_os_descs(g, node);
+	if (usbg_ret && usbg_ret != USBG_ERROR_NOT_FOUND) {
+		ret = usbg_ret;
+		goto out;
+	}
+
+	node = config_setting_add(root, USBG_WEBUSB_TAG, CONFIG_TYPE_GROUP);
+	if (!node)
+		goto out;
+
+	usbg_ret = usbg_export_gadget_webusbs(g, node);
 	if (usbg_ret && usbg_ret != USBG_ERROR_NOT_FOUND) {
 		ret = usbg_ret;
 		goto out;
@@ -1618,6 +1700,51 @@ out:
 	return ret;
 }
 
+static int usbg_import_gadget_webusbs(config_setting_t *root, usbg_gadget *g)
+{
+	config_setting_t *node;
+	int val;
+	int ret = USBG_ERROR_INVALID_TYPE;
+	struct usbg_gadget_webusbs g_webusbs = {0};
+
+#define GET_OPTIONAL_WEBUSB_ATTR(NAME, FIELD, TYPE)			\
+	do {								\
+		node = config_setting_get_member(root, #NAME);		\
+		if (node) {						\
+			if (!usbg_config_is_int(node))			\
+				goto out;				\
+			val = config_setting_get_int(node);		\
+			if (val < 0 || val > ((1L << (sizeof(TYPE)*8)) - 1)) { \
+				ret = USBG_ERROR_INVALID_VALUE;		\
+				goto out;				\
+			}						\
+			g_webusbs.FIELD = (TYPE)val;			\
+		}							\
+	} while (0)
+
+	GET_OPTIONAL_WEBUSB_ATTR(use, use, bool);
+	GET_OPTIONAL_WEBUSB_ATTR(bVendorCode, b_vendor_code, uint8_t);
+	GET_OPTIONAL_WEBUSB_ATTR(bcdVersion, bcd_version, uint16_t);
+
+#undef GET_OPTIONAL_WEBUSB_ATTR
+
+	node = config_setting_get_member(root, "landingPage");
+	if (node) {
+		if (!usbg_config_is_string(node))
+			goto out;
+		/*
+		 * No need to strdup() the string
+		 * as memory is owned by libconfig
+		 */
+		g_webusbs.landing_page = (char *)config_setting_get_string(node);
+	}
+
+	ret = usbg_set_gadget_webusbs(g, &g_webusbs);
+
+out:
+	return ret;
+}
+
 static int usbg_import_gadget_run(usbg_state *s, config_setting_t *root,
 				  const char *name, usbg_gadget **g)
 {
@@ -1696,6 +1823,19 @@ static int usbg_import_gadget_run(usbg_state *s, config_setting_t *root,
 		}
 
 		usbg_ret = usbg_import_gadget_os_descs(node, newg);
+		if (usbg_ret != USBG_SUCCESS)
+			goto error;
+	}
+
+	/* WebUSB descriptors are optional too */
+	node = config_setting_get_member(root, USBG_WEBUSB_TAG);
+	if (node) {
+		if (!config_setting_is_group(node)) {
+			ret = USBG_ERROR_INVALID_TYPE;
+			goto error2;
+		}
+
+		usbg_ret = usbg_import_gadget_webusbs(node, newg);
 		if (usbg_ret != USBG_SUCCESS)
 			goto error;
 	}


### PR DESCRIPTION
Add support to save&restore [WebUsb configfs](https://elixir.bootlin.com/linux/v6.19.3/source/Documentation/ABI/testing/configfs-usb-gadget#L147).

An usb device can be configured to present a 'landingPage' to the os / [chrome based browsers](https://developer.chrome.com/docs/capabilities/usb), which can then direct a user to a WebPage that can use WebUsb to directly talk to a connected USB device.

Configuration:
```
{
        bcdUSB = 0x0200;
        bDeviceClass = 0xEF;
        bDeviceSubClass = 0x02;
        bDeviceProtocol = 0x01;
        bMaxPacketSize0 = 0x40;
        bcdDevice = 0x0001;
        idVendor = 0x1234;
        idProduct = 0x4567;
};
webusb :
{
        use = 1;
        bVendorCode = 0x1;
        bcdVersion = 0x100;
        landingPage = "http://www.example.com";
};
strings = (
{
        lang = 0x409;
        manufacturer = "Acme Corp";
        product = "Gizmo";
        serialnumber = "0123";
} );
functions :
{

```
Result:
```
lsusb -vvv
<snip>
  Platform Device Capability:
    bLength                24
    bDescriptorType        16
    bDevCapabilityType      5
    bReserved               0
    PlatformCapabilityUUID    {3408b638-09a9-47a0-8bfd-a0768815b665}
      WebUSB:
        bcdVersion    1.00
        bVendorCode      1
        iLandingPage     1 http://www.example.com
```